### PR TITLE
tp/bugfix/80 Add health_check url path

### DIFF
--- a/simpletix/config/urls.py
+++ b/simpletix/config/urls.py
@@ -18,10 +18,12 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf.urls.static import static
 from django.conf import settings
+from config.health import health_check
 
 
 urlpatterns = [
     path('', include('simpletix.urls')),
+    path("health/", health_check, name="health_check"),
     path('admin/', admin.site.urls),
     path('events/', include(('events.urls', 'events'), namespace='events')),
     path("accounts/", include(("accounts.urls", "accounts"),


### PR DESCRIPTION
# Summary

This PR fixes the bug of the health_check endpoint that had been removed

# Validation

- `git checkout tp/bigfix/80`
- `python manage.py runserver`
- Each link below should display OK and give 200 response:
  - http://127.0.0.1:8000/health/
  - http://simpletix-dev.eba-fygzzpfp.us-east-1.elasticbeanstalk.com/health/
  - http://simpletix-prod.eba-fygzzpfp.us-east-1.elasticbeanstalk.com/health/