### PR TITLE
Fix DATABASES default variables for Database Connection

### DIFF
--- a/simpletix/config/settings.py
+++ b/simpletix/config/settings.py
@@ -46,22 +46,16 @@ else:
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
-
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB'),
-        'USER': os.getenv('POSTGRES_USER'),
-        'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
-        'HOST': os.getenv('POSTGRES_HOST'),
-        'PORT': os.getenv('POSTGRES_PORT'),
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": secrets["dbname"],
+        "USER": secrets["username"],
+        "PASSWORD": secrets["password"],
+        "HOST": secrets["host"],
+        "PORT": secrets["port"],
     }
 }
-
 
 
 # SECURITY WARNING: don't run with debug turned on in production!


### PR DESCRIPTION
# Summary

This bugfix restores our database connection variables which were removed from development in [this commit](https://github.com/gcivil-nyu-org/team1-mon-fall25/commit/84b989a210d076cd63120ef739f8af0356795a8d#diff-dac5640b5ba67cec4dd75c26a17c97bc2e219daa6f0ddf9d39f7fe8bc53add6e)

# Validation

Take a look at the code changes and visit:

- [dev](http://simpletix-dev.eba-fygzzpfp.us-east-1.elasticbeanstalk.com/)
- [prod](http://simpletix-prod.eba-fygzzpfp.us-east-1.elasticbeanstalk.com)

and verify they are operational