### PR TITLE
Tp/bugfix/144: Remove Extraneous Flash Messages from Templates

### DIFF
--- a/simpletix/accounts/templates/accounts/profile_edit.html
+++ b/simpletix/accounts/templates/accounts/profile_edit.html
@@ -1,4 +1,8 @@
 {% extends "registration/base.html" %}
+
+<!-- ignore flash messages in this template -->
+{% block flash_messages %}{% endblock %}
+
 {% block title %}Edit Organizer Profile · SimpleTix{% endblock %}
 
 {% block content %}

--- a/simpletix/events/templates/events/create_event.html
+++ b/simpletix/events/templates/events/create_event.html
@@ -37,10 +37,6 @@
     <button type="submit" class="btn btn-primary">Save Event</button>
 </form>
 
-{% for message in messages %}
-<p>{{ message }}</p>
-{% endfor %}
-
 <!-- Google Places Autocomplete -->
 <script src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places"></script>
 <script src="{% static 'js/autocomplete.js' %}"></script>

--- a/simpletix/events/templates/events/edit_event.html
+++ b/simpletix/events/templates/events/edit_event.html
@@ -1,5 +1,5 @@
 {% extends 'events/base.html' %}
-{% load static %} 
+{% load static %}
 {% block title %}
     {% if event %}Edit Event{% else %}Create Event{% endif %}
 {% endblock %}
@@ -13,13 +13,6 @@
             Create New Event
         {% endif %}
     </h2>
-    {% if messages %}
-    <ul class="messages">
-        {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="mb-4">

--- a/simpletix/simpletix/templates/simpletix/nav.html
+++ b/simpletix/simpletix/templates/simpletix/nav.html
@@ -96,6 +96,20 @@
       </div>
     </nav>
 
+    <!-- Flash messages should live outside the content block so they always render -->
+    {% block flash_messages %}
+      {% if messages %}
+        <div class="container py-2">
+          {% for message in messages %}
+            <div class="alert alert-{{ message.tags|default:'info' }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endblock %}
+
     <main class="container">
       {% block body %}{% endblock %}
     </main>

--- a/simpletix/templates/registration/base.html
+++ b/simpletix/templates/registration/base.html
@@ -23,7 +23,7 @@
           {% endfor %}
         </div>
       {% endif %}
-    {% end block %}
+    {% endblock %}
 
     <main class="container py-4">
       {% block content %}{% endblock %}

--- a/simpletix/templates/registration/base.html
+++ b/simpletix/templates/registration/base.html
@@ -12,16 +12,18 @@
     {% include "simpletix/nav.html" %}
 
     <!-- Flash messages should live outside the content block so they always render -->
-    {% if messages %}
-      <div class="container py-2">
-        {% for message in messages %}
-          <div class="alert alert-{{ message.tags|default:'info' }} alert-dismissible fade show" role="alert">
-            {{ message }}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-          </div>
-        {% endfor %}
-      </div>
-    {% endif %}
+    {% block flash_messages %}
+      {% if messages %}
+        <div class="container py-2">
+          {% for message in messages %}
+            <div class="alert alert-{{ message.tags|default:'info' }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% end block %}
 
     <main class="container py-4">
       {% block content %}{% endblock %}


### PR DESCRIPTION
# Summary

This PR sees the removal of flash messages in:
- `edit_event`
- `profile_edit`
- `create_event`

# Validation
```
git pull
git checkout tp/bugfix/144
python manage.py runserver
```

1. create a new event
2. click edit event on the newly created event
3. observe that flash messages have moved to the top
4. observe no more flash messages appear below the save button at the bottom of create and edit event pages
