### PR TITLE
temp fix for deleting events with sold tickets

### DIFF
--- a/simpletix/events/views.py
+++ b/simpletix/events/views.py
@@ -15,6 +15,7 @@ from django.shortcuts import (
 from accounts.models import OrganizerProfile
 from tickets.forms import TicketFormSet
 from tickets.models import TicketInfo
+from orders.models import Order
 from .forms import EventForm
 from .models import Event
 
@@ -219,6 +220,15 @@ def delete_event(request, event_id):
     event = get_object_or_404(Event, id=event_id)
 
     if request.method == "POST":
+        has_orders = Order.objects.filter(ticket_info__event=event).exists()
+        if has_orders:
+            # If orders exist, stop and send a friendly error
+            messages.error(
+                request, "This event cannot be deleted because it has existing orders."
+            )
+            # Redirect back to the event detail page (or wherever is appropriate)
+            return redirect("events:event_detail", event_id=event.id)
+
         algolia_delete(event)
 
         event.delete()


### PR DESCRIPTION
# Summary
Check if an event has sold tickets before deleting it. If so, it will stop deleting and return to event detail page with a message. It can be extended to more fine-grained ways to deal with it in future.
# Validation
- `git pull`
- `git checkout xl/bugfix/deleteevent`
- verify cannot delete an event with sold tickets