### PR TITLE
Cancel Btn on Create Event Page

### DIFF
--- a/simpletix/events/templates/events/create_event.html
+++ b/simpletix/events/templates/events/create_event.html
@@ -152,7 +152,8 @@
         </div>
 
         <!-- Actions -->
-        <div class="d-flex justify-content-end mt-4">
+        <div class="d-flex justify-content-between mt-4">
+          <a href="{% url 'events:event_list' %}" class="btn btn-secondary">Cancel</a>
           <button type="submit" class="btn btn-primary px-4">
             Save Event
           </button>

--- a/simpletix/events/templates/events/edit_event.html
+++ b/simpletix/events/templates/events/edit_event.html
@@ -148,15 +148,15 @@
 
         <!-- Actions -->
         <div class="d-flex justify-content-between mt-4">
-          <button type="submit" class="btn btn-primary">
-            {% if event %}Save Changes{% else %}Create Event{% endif %}
-          </button>
-
           {% if event %}
             <a href="{% url 'events:event_detail' event.id %}" class="btn btn-secondary">Cancel</a>
           {% else %}
             <a href="{% url 'events:event_list' %}" class="btn btn-secondary">Cancel</a>
           {% endif %}
+
+          <button type="submit" class="btn btn-primary">
+            {% if event %}Save Changes{% else %}Create Event{% endif %}
+          </button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
# Summary
- add a cancel button to the create event page and allow user to exit the page
- exchange cancel and save changes buttons on edit event page to make back/cancel buttons on the left side of all pages
# Validation
- `git pull`
- `git checkout xl/bugfix/169`
- Verify buttons are positioned as described and work properly