### PR TITLE
Fixed Full-name and Phone number validation issue in edit profile

### DIFF
--- a/simpletix/accounts/forms.py
+++ b/simpletix/accounts/forms.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 
 from io import BytesIO
+import re
 from PIL import Image, ImageOps  # for EXIF orientation fix
 
 from .models import OrganizerProfile
@@ -55,6 +56,36 @@ class OrganizerProfileForm(forms.ModelForm):
             ),
             "profile_photo": forms.ClearableFileInput(attrs={"class": "form-control"}),
         }
+
+    def clean_full_name(self):
+        """
+        Enforce a human-looking full name:
+
+        - required (non-empty after trimming)
+        - must contain at least one alphabetic character
+        - only allow letters, spaces, hyphens, apostrophes and periods
+        """
+        full_name = (self.cleaned_data.get("full_name") or "").strip()
+
+        if not full_name:
+            raise ValidationError("Please enter your full name.")
+
+        # Require at least one alphabetic character
+        if not re.search(r"[A-Za-z]", full_name):
+            raise ValidationError(
+                "Full name must include at least one letter."
+            )
+
+        # Only allow safe character set
+        allowed_pattern = r"^[A-Za-z\s\-\.'’]+$"
+        if not re.match(allowed_pattern, full_name):
+            raise ValidationError(
+                "Full name can only contain letters, spaces, hyphens, "
+                "apostrophes, and periods."
+            )
+
+        return full_name
+
 
     def clean_profile_photo(self):
         """

--- a/simpletix/accounts/forms.py
+++ b/simpletix/accounts/forms.py
@@ -57,18 +57,21 @@ class OrganizerProfileForm(forms.ModelForm):
             "profile_photo": forms.ClearableFileInput(attrs={"class": "form-control"}),
         }
 
+
     def clean_full_name(self):
         """
-        Enforce a human-looking full name:
+        Enforce a human-looking full name when provided:
 
-        - required (non-empty after trimming)
-        - must contain at least one alphabetic character
-        - only allow letters, spaces, hyphens, apostrophes and periods
+        - If left blank, keep existing behavior (optional field).
+        - If provided, must contain at least one alphabetic character.
+        - Only allow letters, spaces, hyphens, apostrophes and periods.
         """
         full_name = (self.cleaned_data.get("full_name") or "").strip()
 
+        # Preserve previous behavior: full_name is optional.
+        # We only validate when the user actually enters something.
         if not full_name:
-            raise ValidationError("Please enter your full name.")
+            return full_name
 
         # Require at least one alphabetic character
         if not re.search(r"[A-Za-z]", full_name):
@@ -85,7 +88,6 @@ class OrganizerProfileForm(forms.ModelForm):
             )
 
         return full_name
-
 
     def clean_profile_photo(self):
         """

--- a/simpletix/accounts/forms.py
+++ b/simpletix/accounts/forms.py
@@ -7,7 +7,7 @@ from django.core.files.base import ContentFile
 
 from io import BytesIO
 import re
-from PIL import Image, ImageOps  # for EXIF orientation fix
+from PIL import Image, ImageOps
 
 from .models import OrganizerProfile
 
@@ -57,7 +57,6 @@ class OrganizerProfileForm(forms.ModelForm):
             "profile_photo": forms.ClearableFileInput(attrs={"class": "form-control"}),
         }
 
-
     def clean_full_name(self):
         """
         Enforce a human-looking full name when provided:
@@ -75,9 +74,7 @@ class OrganizerProfileForm(forms.ModelForm):
 
         # Require at least one alphabetic character
         if not re.search(r"[A-Za-z]", full_name):
-            raise ValidationError(
-                "Full name must include at least one letter."
-            )
+            raise ValidationError("Full name must include at least one letter.")
 
         # Only allow safe character set
         allowed_pattern = r"^[A-Za-z\s\-\.'’]+$"
@@ -88,6 +85,39 @@ class OrganizerProfileForm(forms.ModelForm):
             )
 
         return full_name
+    
+    def clean_phone(self):
+        """
+        Validate phone numbers:
+
+        - Optional: if left blank, keep existing behavior.
+        - If provided, allow only digits, spaces, +, -, (, ).
+        - Enforce a realistic digit length (7–15 digits).
+        """
+        phone = (self.cleaned_data.get("phone") or "").strip()
+
+        # Phone is optional
+        if not phone:
+            return phone
+
+        # Only allow digits and common phone punctuation
+        allowed_pattern = r"^[0-9+\-\s()]+$"
+        if not re.match(allowed_pattern, phone):
+            raise ValidationError(
+                "Phone number can only contain digits and the characters "
+                "+, -, spaces, and parentheses."
+            )
+
+        # Count only the digits to validate length
+        digit_count = sum(ch.isdigit() for ch in phone)
+        if digit_count < 10 or digit_count > 10:
+            raise ValidationError(
+                "Phone number is invalid"
+            )
+
+        return phone
+
+
 
     def clean_profile_photo(self):
         """

--- a/simpletix/accounts/forms.py
+++ b/simpletix/accounts/forms.py
@@ -8,7 +8,6 @@ from django.core.files.base import ContentFile
 from io import BytesIO
 import re
 from PIL import Image, ImageOps
-
 from .models import OrganizerProfile
 
 
@@ -85,7 +84,7 @@ class OrganizerProfileForm(forms.ModelForm):
             )
 
         return full_name
-    
+
     def clean_phone(self):
         """
         Validate phone numbers:
@@ -111,13 +110,9 @@ class OrganizerProfileForm(forms.ModelForm):
         # Count only the digits to validate length
         digit_count = sum(ch.isdigit() for ch in phone)
         if digit_count < 10 or digit_count > 10:
-            raise ValidationError(
-                "Phone number is invalid"
-            )
+            raise ValidationError("Phone number is invalid")
 
         return phone
-
-
 
     def clean_profile_photo(self):
         """

--- a/simpletix/accounts/templates/accounts/profile_edit.html
+++ b/simpletix/accounts/templates/accounts/profile_edit.html
@@ -3,17 +3,21 @@
 <!-- ignore flash messages in this template -->
 {% block flash_messages %}{% endblock %}
 
-{% block title %}Edit Organizer Profile · SimpleTix{% endblock %}
+{% block title %}Edit Profile · SimpleTix{% endblock %}
 
 {% block content %}
   <div class="card">
     <h1 class="mb-1">
-      Edit {{ request.user.uprofile.role|default:"attendee"|title }} Profile
+      Edit {{ profile_role }} Profile
     </h1>
     <p class="muted">Keep your public info up to date.</p>
 
     <!-- Important: action points to the view, include csrf, include hidden next -->
-    <form method="post" enctype="multipart/form-data" action="{% url 'accounts:profile_edit' %}" class="form" novalidate>
+    <form method="post"
+          enctype="multipart/form-data"
+          action="{% url 'accounts:profile_edit' %}"
+          class="form"
+          novalidate>
       {% csrf_token %}
       <input type="hidden" name="next" value="{{ next }}">
 

--- a/simpletix/accounts/tests/test_accounts_forms_profile_photo.py
+++ b/simpletix/accounts/tests/test_accounts_forms_profile_photo.py
@@ -37,7 +37,11 @@ def test_profile_photo_png_alpha_normalized_to_jpeg_and_saved(tmp_path, settings
     f = SimpleUploadedFile("avatar.png", png_bytes, content_type="image/png")
 
     form = OrganizerProfileForm(
-        data={"full_name": "A", "contact_email": "a@example.com", "phone": "1234567890"},
+        data={
+            "full_name": "A",
+            "contact_email": "a@example.com",
+            "phone": "1234567890",
+        },
         files={"profile_photo": f},
         instance=op,
     )

--- a/simpletix/accounts/tests/test_accounts_forms_profile_photo.py
+++ b/simpletix/accounts/tests/test_accounts_forms_profile_photo.py
@@ -37,7 +37,7 @@ def test_profile_photo_png_alpha_normalized_to_jpeg_and_saved(tmp_path, settings
     f = SimpleUploadedFile("avatar.png", png_bytes, content_type="image/png")
 
     form = OrganizerProfileForm(
-        data={"full_name": "A", "contact_email": "a@example.com", "phone": "123"},
+        data={"full_name": "A", "contact_email": "a@example.com", "phone": "1234567890"},
         files={"profile_photo": f},
         instance=op,
     )

--- a/simpletix/accounts/views.py
+++ b/simpletix/accounts/views.py
@@ -164,7 +164,14 @@ def signup(request):
 
 @login_required
 def profile_edit(request):
+
     profile, _ = OrganizerProfile.objects.get_or_create(user=request.user)
+
+    session_role = request.session.get("desired_role")
+    db_role = getattr(getattr(request.user, "uprofile", None), "role", None)
+    effective_role = (session_role or db_role or "attendee").lower()
+
+    profile_role = "Organizer" if effective_role == "organizer" else "Attendee"
 
     if request.method == "POST":
         form = OrganizerProfileForm(request.POST, request.FILES, instance=profile)
@@ -179,7 +186,11 @@ def profile_edit(request):
     return render(
         request,
         "accounts/profile_edit.html",
-        {"form": form, "next": request.GET.get("next", "/")},
+        {
+            "form": form,
+            "next": request.GET.get("next", "/"),
+            "profile_role": profile_role,
+        },
     )
 
 


### PR DESCRIPTION
**Summary**
This PR fixes #175 & #176, where the Edit Profile page allowed invalid names (symbols/numbers only) and the Phone number displayed the wrong profile type for organizers/Attendees.

**Validation**

```
git pull
git checkout dk/bugfix_175
python manage.py runserver
```

- Log in as Attendee/Organizer -> go to Edit Profile -> header shows Edit Attendee/Organizer Profile.
- Try entering only symbols/numbers in the Full Name field -> form shows validation error, save is blocked.
- Try entering an invalid number with symbols/characters in the Phone number field -> form shows validation error, save is blocked.
