### PR TITLE
Clickable Cards

### DIFF
--- a/simpletix/events/templates/events/event_list.html
+++ b/simpletix/events/templates/events/event_list.html
@@ -160,7 +160,7 @@
     <div class="row g-4 events-grid">
         {% for event in events %}
         <div class="col-md-4">
-            <div class="card event-card futuristic-card">
+            <div class="card event-card futuristic-card clickable-card" data-url="{% url 'events:event_detail' event.id %}">
                 <div class="event-card-media">
                     {% if event.banner %}
                         <img src="{{ event.banner.url }}" class="card-img-top" alt="{{ event.title }}">
@@ -304,4 +304,25 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 </script>
 
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const cards = document.querySelectorAll('.clickable-card');
+
+    cards.forEach(card => {
+        card.addEventListener('click', function(e) {
+            // CHECK: Did the user click on a link (a) or a button?
+            // If yes, do nothing (let the button do its job).
+            if (e.target.closest('a') || e.target.closest('button')) {
+                return;
+            }
+
+            // Otherwise, go to the card's URL
+            const url = this.getAttribute('data-url');
+            if (url) {
+                window.location.href = url;
+            }
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/simpletix/static/events/event_lists.css
+++ b/simpletix/static/events/event_lists.css
@@ -93,6 +93,7 @@
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
     backdrop-filter: blur(12px);
+    cursor: pointer;
 }
 
 /* Glow edge on hover */


### PR DESCRIPTION
# Summary
make cards in event list clickable as suggested in #180 
# Validation
`git pull`
`git checkout xl/bugfix/180`
`python manage.py runserver`
Confirm that clicking any position of the event card in list directs the user to the corresponding event details page