### PR TITLE
Removed edit and delete from event details page + updated the management flow.

### DIFF
--- a/simpletix/events/models.py
+++ b/simpletix/events/models.py
@@ -22,7 +22,6 @@ class Event(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
-    # 👇 NEW FIELDS for cancellation
     is_cancelled = models.BooleanField(default=False)
     cancelled_at = models.DateTimeField(null=True, blank=True)
 

--- a/simpletix/events/templates/events/event_detail.html
+++ b/simpletix/events/templates/events/event_detail.html
@@ -245,26 +245,29 @@
           Back to Events
         </a>
 
-        <div class="event-actions-right">
-          {% if request.session.desired_role == 'organizer' and event.organizer.user == user %}
-            {% if event.is_cancelled %}
-              <span class="badge bg-danger-subtle text-danger fw-semibold">
-                Event cancelled
-              </span>
-            {% endif %}
-            <a href="{% url 'events:edit_event' event.id %}" class="btn btn-warning">Edit Event</a>
-            <a href="{% url 'events:delete_event' event.id %}" class="btn btn-danger">Delete Event</a>
-          {% elif request.session.desired_role != 'organizer' %}
-            {% if not event.is_cancelled %}
-              <a href="{% url 'orders:order' event.id %}" class="btn btn-primary">Buy Ticket</a>
-            {% else %}
-              <span class="badge bg-light text-muted">
-                Event cancelled · Tickets unavailable
-              </span>
-            {% endif %}
-          {% endif %}
-        </div>
-      </div>
+  <div class="event-actions-right">
+    {# Organizer viewing the page #}
+    {% if request.session.desired_role == 'organizer' and event.organizer.user == user %}
+      {% if event.is_cancelled %}
+        <span class="badge bg-danger-subtle text-danger fw-semibold">
+          Event cancelled
+        </span>
+      {% endif %}
+
+
+    {# Attendees / non-organizers #}
+    {% elif request.session.desired_role != 'organizer' %}
+      {% if not event.is_cancelled %}
+        <a href="{% url 'orders:order' event.id %}" class="btn btn-primary">Buy Ticket</a>
+      {% else %}
+        <span class="badge bg-light text-muted">
+          Event cancelled · Tickets unavailable
+        </span>
+      {% endif %}
+    {% endif %}
+  </div>
+</div>
+
     </div>
   </div>
 </div>

--- a/simpletix/events/templates/events/event_management_dashboard.html
+++ b/simpletix/events/templates/events/event_management_dashboard.html
@@ -55,11 +55,21 @@
                   {% endif %}
                 </td>
                 <td class="stx-cell-actions">
-                  <a href="{% url 'events:edit_event' event.id %}"
-                     class="stx-btn-table stx-btn-table-secondary me-2"
-                     role="button">
-                    Edit
-                  </a>
+                  {# Hide/disable Edit for cancelled events #}
+                  {% if not event.is_cancelled %}
+                    <a href="{% url 'events:edit_event' event.id %}"
+                       class="stx-btn-table stx-btn-table-secondary me-2"
+                       role="button">
+                      Edit
+                    </a>
+                  {% else %}
+                    <button class="stx-btn-table stx-btn-table-secondary stx-btn-table-disabled me-2"
+                            type="button"
+                            disabled
+                            aria-disabled="true">
+                      Edit
+                    </button>
+                  {% endif %}
                   <a href="{% url 'orders:event_order_list' event.id %}"
                      class="stx-btn-table stx-btn-table-primary"
                      role="button">

--- a/simpletix/events/templates/events/event_management_dashboard.html
+++ b/simpletix/events/templates/events/event_management_dashboard.html
@@ -55,13 +55,22 @@
                   {% endif %}
                 </td>
                 <td class="stx-cell-actions">
-                  <a href="{% url 'orders:event_order_list' event.id %}" class="btn btn-sm btn-outline-primary me-2">
+                  <a href="{% url 'events:edit_event' event.id %}"
+                     class="stx-btn-table stx-btn-table-secondary me-2"
+                     role="button">
+                    Edit
+                  </a>
+                  <a href="{% url 'orders:event_order_list' event.id %}"
+                     class="stx-btn-table stx-btn-table-primary"
+                     role="button">
                     Manage Orders
                   </a>
                 </td>
                 <td class="stx-cell-actions">
                   {% if not event.is_cancelled %}
-                    <a href="{% url 'events:cancel_event' event.id %}" class="stx-btn-ghost-danger">
+                    <a href="{% url 'events:cancel_event' event.id %}"
+                       class="stx-btn-table stx-btn-table-danger"
+                       role="button">
                       Cancel event
                     </a>
                   {% else %}

--- a/simpletix/events/views.py
+++ b/simpletix/events/views.py
@@ -249,7 +249,7 @@ def edit_event(request, event_id):
     )
 
 
-# Delete Event
+# Delete Event  (now behaves like a soft cancel)
 @custom_login_required(extra_params={"role": "organizer"})
 @organizer_owns_event
 def delete_event(request, event_id):
@@ -257,26 +257,38 @@ def delete_event(request, event_id):
 
     if request.method == "POST":
         has_orders = Order.objects.filter(ticket_info__event=event).exists()
-        if has_orders:
-            # If orders exist, stop and send a friendly error
-            messages.error(
-                request, "This event cannot be deleted because it has existing orders."
-            )
-            # Redirect back to the event detail page (or wherever is appropriate)
-            return redirect("events:event_detail", event_id=event.id)
 
+        # Mark event as cancelled instead of deleting from DB
+        event.cancel()
+
+        # Remove from Algolia search index so it doesn’t appear in search
         algolia_delete(event)
 
-        event.delete()
-        messages.success(request, "Event deleted successfully!")
-        return redirect("events:event_list")
+        # If there were orders, notify + refund
+        if has_orders:
+            services.notify_event_cancellation(event)
+            services.initiate_event_refunds(event)
+            messages.success(
+                request,
+                f'"{event.title}" has been cancelled. '
+                "Attendees will be notified and refunds will be processed.",
+            )
+        else:
+            messages.success(
+                request,
+                f'"{event.title}" has been cancelled. No attendees had purchased tickets.',
+            )
+
+        return redirect("events:event_management_dashboard")
+
     return render(request, "events/delete_event.html", {"event": event})
+
 
 
 # Event List
 # --- Event List (stable + slick-compatible version) ---
 def event_list(request):
-    events = Event.objects.all().distinct()
+    events = Event.objects.filter(is_cancelled=False).distinct()
 
     # --- Sorting Inputs ---
     price_sort = request.GET.get("price_sort")
@@ -453,8 +465,10 @@ def event_management_dashboard(request):
         messages.error(request, "You must be an organizer to access this page.")
         return redirect("events:event_list")  # fallback
 
-    events = Event.objects.filter(organizer=organizer_profile).order_by(
-        "-date", "-time"
+    # Show all events (scheduled + cancelled) for this organizer
+    events = (
+        Event.objects.filter(organizer=organizer_profile)
+        .order_by("-date", "-time")
     )
 
     return render(
@@ -462,6 +476,7 @@ def event_management_dashboard(request):
         "events/event_management_dashboard.html",
         {"events": events},
     )
+
 
 
 @login_required

--- a/simpletix/events/views.py
+++ b/simpletix/events/views.py
@@ -195,6 +195,13 @@ def create_event(request):
 def edit_event(request, event_id):
     event = get_object_or_404(Event, id=event_id)
 
+    if event.is_cancelled:
+        messages.error(
+            request,
+            "This event has already been cancelled and " "can no longer be edited.",
+        )
+        return redirect("events:event_detail", event_id=event.id)
+
     if request.method == "POST":
         form = EventForm(request.POST, request.FILES, instance=event)
         formset = TicketFormSet(request.POST, request.FILES, instance=event)
@@ -254,6 +261,13 @@ def edit_event(request, event_id):
 @organizer_owns_event
 def delete_event(request, event_id):
     event = get_object_or_404(Event, id=event_id)
+
+    if event.is_cancelled:
+        messages.error(
+            request,
+            "This event has already been cancelled and cannot be deleted.",
+        )
+        return redirect("events:event_detail", event_id=event.id)
 
     if request.method == "POST":
         has_orders = Order.objects.filter(ticket_info__event=event).exists()
@@ -496,6 +510,13 @@ def cancel_event(request, event_id):
     if event.is_cancelled:
         messages.info(request, "This event is already cancelled.")
         return redirect("events:event_management_dashboard")
+
+    if event.is_cancelled:
+        messages.info(
+            request,
+            f'"{event.title}" is already cancelled.',
+        )
+        return redirect("events:event_detail", event_id=event.id)
 
     if request.method == "POST":
         # 1) Update event status

--- a/simpletix/events/views.py
+++ b/simpletix/events/views.py
@@ -276,13 +276,15 @@ def delete_event(request, event_id):
         else:
             messages.success(
                 request,
-                f'"{event.title}" has been cancelled. No attendees had purchased tickets.',
+                (
+                    f'"{event.title}" has been cancelled. '
+                    "No attendees had purchased tickets."
+                ),
             )
 
         return redirect("events:event_management_dashboard")
 
     return render(request, "events/delete_event.html", {"event": event})
-
 
 
 # Event List
@@ -466,9 +468,8 @@ def event_management_dashboard(request):
         return redirect("events:event_list")  # fallback
 
     # Show all events (scheduled + cancelled) for this organizer
-    events = (
-        Event.objects.filter(organizer=organizer_profile)
-        .order_by("-date", "-time")
+    events = Event.objects.filter(organizer=organizer_profile).order_by(
+        "-date", "-time"
     )
 
     return render(
@@ -476,7 +477,6 @@ def event_management_dashboard(request):
         "events/event_management_dashboard.html",
         {"events": events},
     )
-
 
 
 @login_required

--- a/simpletix/static/events/event_management_dashboard.css
+++ b/simpletix/static/events/event_management_dashboard.css
@@ -226,3 +226,14 @@
 .stx-btn-table-danger:hover {
   background: #b91c1c !important;
 }
+
+/* Disabled table button: used for Edit on cancelled events */
+.stx-btn-table-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: #e5e7eb;            /* light grey */
+  color: #6b7280;                 /* muted text */
+  border-color: rgba(148, 163, 184, 0.5);
+  box-shadow: none;
+}
+

--- a/simpletix/static/events/event_management_dashboard.css
+++ b/simpletix/static/events/event_management_dashboard.css
@@ -126,6 +126,7 @@
   white-space: nowrap;
 }
 
+/* legacy cancel style (safe to keep for any old uses) */
 .stx-btn-ghost-danger {
   border-radius: 999px;
   padding: 6px 14px;
@@ -166,4 +167,62 @@
 
 .stx-col-actions {
   width: 160px;
+}
+
+/* unified pill buttons for Edit / Manage Orders / Cancel */
+.stx-btn-table {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none !important;
+  color: #111827 !important;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.1s ease;
+}
+
+.stx-btn-table:hover {
+  transform: translateY(-1px);
+}
+
+/* primary (Manage Orders) – solid blue pill */
+.stx-btn-table-primary {
+  border-color: #4778e0 !important;
+  background: #4778e0 !important;
+  color: #ffffff !important;
+}
+
+.stx-btn-table-primary:hover {
+  background: #1d4ed8 !important;
+}
+
+/* secondary (Edit) – subtle grey-outline pill */
+.stx-btn-table-secondary {
+  border-color: #e5e7eb !important;
+  background: #ffffff !important;
+  color: #374151 !important;
+}
+
+.stx-btn-table-secondary:hover {
+  background: #f3f4f6 !important;
+}
+
+/* danger (Cancel event) – solid red pill */
+.stx-btn-table-danger {
+  border-color: #941515 !important;
+  background: #941515 !important;
+  color: #ffffff !important;
+}
+
+.stx-btn-table-danger:hover {
+  background: #b91c1c !important;
 }


### PR DESCRIPTION
**Summary:**

This PR continues the event cancellation feature and addresses issue #198. 

**Validation**

```
git pull
git checkout dk/feature/33
python manage.py runserver
```

**How to test:**
- Login as an Organizer and create an event.
- Verify it appears in the Manage Events dashboard with Edit / Manage Orders / Cancel buttons.
- Login as an Attendee and purchase a ticket for that event.
- Login back as the Organizer, go to Manage Events, click Cancel Event → Confirm.

**Verify:**
- Event shows Cancelled badge and No actions.
- Cancelled event still appears in Manage Events.
- Cancelled event does NOT appear in the public Events list.