### PR TITLE
Bug Fix: Edit profile should not throw nginx error page when larger image is uploaded.

### DIFF
--- a/simpletix/accounts/templates/accounts/profile_edit.html
+++ b/simpletix/accounts/templates/accounts/profile_edit.html
@@ -57,4 +57,39 @@
       </div>
     </form>
   </div>
+
+  <script>
+    (function () {
+      // Adjust this if your actual nginx/Django limit is different
+      var MAX_SIZE_MB = 10;
+      var MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
+
+      var form = document.querySelector("form.form");
+      if (!form) return;
+
+      var fileInput = form.querySelector('input[type="file"][name="profile_photo"]');
+      var errorEl = document.getElementById("profile-photo-error");
+
+      if (!fileInput || !errorEl) return;
+
+      form.addEventListener("submit", function (e) {
+        var file = fileInput.files && fileInput.files[0];
+        // If there is a file and it's too large, block submit
+        if (file && file.size > MAX_SIZE_BYTES) {
+          e.preventDefault();
+          errorEl.textContent =
+            "Maximum file size is " + MAX_SIZE_MB + " MB. Please choose a smaller image.";
+          errorEl.style.display = "block";
+        }
+      });
+
+      fileInput.addEventListener("change", function () {
+        // Clear error when user picks a new file
+        if (errorEl.style.display === "block") {
+          errorEl.textContent = "";
+          errorEl.style.display = "none";
+        }
+      });
+    })();
+  </script>
 {% endblock %}

--- a/simpletix/events/templates/events/create_event.html
+++ b/simpletix/events/templates/events/create_event.html
@@ -72,7 +72,7 @@
 
           <!-- Banner -->
           <div class="col-md-6">
-            <label for="{{ form.banner.id_for_label }}" class="form-label">Banner</label>
+            <label for "{{ form.banner.id_for_label }}" class="form-label">Banner</label>
             {{ form.banner }}
             {% if form.banner.errors %}
               <div class="errorlist">{{ form.banner.errors }}</div>
@@ -80,6 +80,8 @@
             {% if form.banner.help_text %}
               <div class="helptext">{{ form.banner.help_text }}</div>
             {% endif %}
+            <div class="text-muted small">Maximum file size: 10&nbsp;MB.</div>
+            <div id="banner-size-error" class="text-danger small" style="display:none;"></div>
           </div>
 
           <!-- Video -->
@@ -92,6 +94,8 @@
             {% if form.video.help_text %}
               <div class="helptext">{{ form.video.help_text }}</div>
             {% endif %}
+            <div class="text-muted small">Maximum file size: 10&nbsp;MB.</div>
+            <div id="video-size-error" class="text-danger small" style="display:none;"></div>
           </div>
         </div>
 
@@ -167,4 +171,75 @@
 <script src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places"></script>
 <script src="{% static 'js/autocomplete.js' %}"></script>
 <script src="{% static 'events/js/toggler.js' %}"></script>
+
+<script>
+  (function () {
+    var MAX_SIZE_MB = 10;
+    var MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
+
+    var form = document.querySelector('form[method="POST"][enctype="multipart/form-data"]');
+    if (!form) return;
+
+    var bannerInput = form.querySelector('input[type="file"][name="banner"]');
+    var videoInput = form.querySelector('input[type="file"][name="video"]');
+    var bannerError = document.getElementById("banner-size-error");
+    var videoError = document.getElementById("video-size-error");
+
+    function clearError(el) {
+      if (!el) return;
+      el.textContent = "";
+      el.style.display = "none";
+    }
+
+    function setError(el, message) {
+      if (!el) return;
+      el.textContent = message;
+      el.style.display = "block";
+    }
+
+    form.addEventListener("submit", function (e) {
+      var hasError = false;
+
+      if (bannerInput && bannerInput.files && bannerInput.files[0]) {
+        if (bannerInput.files[0].size > MAX_SIZE_BYTES) {
+          hasError = true;
+          setError(
+            bannerError,
+            "Maximum file size is " + MAX_SIZE_MB + " MB. Please choose a smaller banner image."
+          );
+        } else {
+          clearError(bannerError);
+        }
+      }
+
+      if (videoInput && videoInput.files && videoInput.files[0]) {
+        if (videoInput.files[0].size > MAX_SIZE_BYTES) {
+          hasError = true;
+          setError(
+            videoError,
+            "Maximum file size is " + MAX_SIZE_MB + " MB. Please choose a smaller video."
+          );
+        } else {
+          clearError(videoError);
+        }
+      }
+
+      if (hasError) {
+        e.preventDefault();
+      }
+    });
+
+    if (bannerInput) {
+      bannerInput.addEventListener("change", function () {
+        clearError(bannerError);
+      });
+    }
+
+    if (videoInput) {
+      videoInput.addEventListener("change", function () {
+        clearError(videoError);
+      });
+    }
+  })();
+</script>
 {% endblock %}

--- a/simpletix/events/templates/events/edit_event.html
+++ b/simpletix/events/templates/events/edit_event.html
@@ -167,4 +167,97 @@
 <script src="https://maps.googleapis.com/maps/api/js?key={{ GOOGLE_MAPS_API_KEY }}&libraries=places"></script>
 <script src="{% static 'js/autocomplete.js' %}"></script>
 <script src="{% static 'events/js/toggler.js' %}"></script>
+
+<script>
+  (function () {
+    var MAX_SIZE_MB = 10;
+    var MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
+
+    var form = document.querySelector('form[method="post"][enctype="multipart/form-data"]');
+    if (!form) return;
+
+    function setupFileField(fieldName, errorIdSuffix) {
+      var input = form.querySelector('input[type="file"][name="' + fieldName + '"]');
+      if (!input) {
+        return { input: null, errorEl: null };
+      }
+
+      // Helper text
+      var helper = document.createElement("div");
+      helper.className = "text-muted small";
+      helper.textContent = "Maximum file size: " + MAX_SIZE_MB + " MB.";
+
+      // Error container
+      var errorEl = document.createElement("div");
+      errorEl.id = errorIdSuffix;
+      errorEl.className = "text-danger small";
+      errorEl.style.display = "none";
+
+      // Insert just after the input
+      input.insertAdjacentElement("afterend", errorEl);
+      input.insertAdjacentElement("afterend", helper);
+
+      return { input: input, errorEl: errorEl };
+    }
+
+    var bannerField = setupFileField("banner", "edit-banner-size-error");
+    var videoField = setupFileField("video", "edit-video-size-error");
+
+    function clearError(errorEl) {
+      if (!errorEl) return;
+      errorEl.textContent = "";
+      errorEl.style.display = "none";
+    }
+
+    function setError(errorEl, message) {
+      if (!errorEl) return;
+      errorEl.textContent = message;
+      errorEl.style.display = "block";
+    }
+
+    form.addEventListener("submit", function (e) {
+      var hasError = false;
+
+      if (bannerField.input && bannerField.input.files && bannerField.input.files[0]) {
+        if (bannerField.input.files[0].size > MAX_SIZE_BYTES) {
+          hasError = true;
+          setError(
+            bannerField.errorEl,
+            "Maximum file size is " + MAX_SIZE_MB + " MB. Please choose a smaller banner image."
+          );
+        } else {
+          clearError(bannerField.errorEl);
+        }
+      }
+
+      if (videoField.input && videoField.input.files && videoField.input.files[0]) {
+        if (videoField.input.files[0].size > MAX_SIZE_BYTES) {
+          hasError = true;
+          setError(
+            videoField.errorEl,
+            "Maximum file size is " + MAX_SIZE_MB + " MB. Please choose a smaller video."
+          );
+        } else {
+          clearError(videoField.errorEl);
+        }
+      }
+
+      if (hasError) {
+        e.preventDefault();
+      }
+    });
+
+    if (bannerField.input) {
+      bannerField.input.addEventListener("change", function () {
+        clearError(bannerField.errorEl);
+      });
+    }
+
+    if (videoField.input) {
+      videoField.input.addEventListener("change", function () {
+        clearError(videoField.errorEl);
+      });
+    }
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
**Summary**
This PR addresses bug #177, where the Edit Attendee Profile page generates nginx-level 413 Request Entity Too Large errors when users attempt to upload excessively large profile photos.

**Validate**
```
git pull
git checkout dk/bug/177
python manage.py runserver
```

**How to Test:**
- Go to Edit Profile.
- Try uploading a file under 2MB → Save works normally.
- Try uploading a very large file (e.g., 10–20MB) → Form blocks submission and shows an inline error instead of navigating to the nginx error page.

